### PR TITLE
Small improvements for the requestor agent

### DIFF
--- a/requestor/requestor_agent_stub.py
+++ b/requestor/requestor_agent_stub.py
@@ -4,8 +4,7 @@ import asyncio
 
 async def main(yem):
     erigon = yem.create_erigon()
-    await erigon.start()
-    print(f"New Erigon deployed, id: {erigon.id}")
+    print(f"New Erigon starting, id: {erigon.id}")
 
     while True:
         print(f"Erigon {erigon.id} update: {erigon.runtime_state.timestamp} "

--- a/requestor/worker.py
+++ b/requestor/worker.py
@@ -46,9 +46,13 @@ async def worker(ctx: WorkContext, tasks):
     erigon.started = True
 
     #   REQUEST PROCESSING
-    async for requesting_future in process_commands(ctx, erigon):
-        processing_future = yield ctx.commit()
-        result = parse_result(processing_future.result())
-        requesting_future.set_result(result)
+    try:
+        async for requesting_future in process_commands(ctx, erigon):
+            processing_future = yield ctx.commit()
+            result = parse_result(processing_future.result())
+            requesting_future.set_result(result)
+    except Exception as e:
+        print("COMMAND FAILED", e)
+        erigon.disable()
 
     task.accept_result(result='DONE')

--- a/requestor/worker.py
+++ b/requestor/worker.py
@@ -39,8 +39,6 @@ async def worker(ctx: WorkContext, tasks):
         yield ctx.commit()
     except Exception as e:
         print("DEPLOYMENT FAILED ", e)
-        #   Put the deployment_fut back to queue so when this function
-        #   restarts we'll be in the same state
         task.reject_result(retry=True)
         return
     erigon.started = True
@@ -54,5 +52,6 @@ async def worker(ctx: WorkContext, tasks):
     except Exception as e:
         print("COMMAND FAILED", e)
         erigon.disable()
+        requesting_future.set_result({'status': 'FAILED'})
 
     task.accept_result(result='DONE')

--- a/requestor/worker.py
+++ b/requestor/worker.py
@@ -31,9 +31,8 @@ async def worker(ctx: WorkContext, tasks):
         return
 
     #   DEPLOYMENT
-    deployment_fut = await erigon.queue.get()
     try:
-        #   NOTE: this is not necessary, but without any ctx.run() it seems that
+        #   NOTE: this ctx.run() is not necessary, but without any ctx.run() it seems that
         #   ctx.commit() does nothing and we would deploy only when first status
         #   request comes
         ctx.run('STATUS')
@@ -42,12 +41,9 @@ async def worker(ctx: WorkContext, tasks):
         print("DEPLOYMENT FAILED ", e)
         #   Put the deployment_fut back to queue so when this function
         #   restarts we'll be in the same state
-        erigon.queue.put_nowait(deployment_fut)
         task.reject_result(retry=True)
         return
-
-    #   We got here -> deployment succeeded
-    deployment_fut.set_result({'status': 'DEPLOYED'})
+    erigon.started = True
 
     #   REQUEST PROCESSING
     async for requesting_future in process_commands(ctx, erigon):

--- a/requestor/yagna_erigon_manager.py
+++ b/requestor/yagna_erigon_manager.py
@@ -49,8 +49,10 @@ class Erigon():
         return await self.run('STATUS')
 
     async def stop(self):
+        if self.stopped:
+            return
+
         self.disable()
-        print(f"STOPPING {self}")
         if self.started:
             return await self.run('STOP')
         else:
@@ -60,6 +62,7 @@ class Erigon():
         if self.stopped:
             return
         self.stopped = True
+        print(f"STOPPING {self}")
 
     async def run(self, cmd):
         fut = asyncio.get_running_loop().create_future()

--- a/requestor/yagna_erigon_manager.py
+++ b/requestor/yagna_erigon_manager.py
@@ -49,15 +49,17 @@ class Erigon():
         return await self.run('STATUS')
 
     async def stop(self):
+        self.disable()
+        print(f"STOPPING {self}")
+        if self.started:
+            return await self.run('STOP')
+        else:
+            return "not started yet"
+
+    def disable(self):
         if self.stopped:
             return
         self.stopped = True
-
-        print(f"STOPPING {self}")
-        if not self.started:
-            return "not started yet"
-        else:
-            return await self.run('STOP')
 
     async def run(self, cmd):
         fut = asyncio.get_running_loop().create_future()

--- a/requestor/yagna_erigon_manager.py
+++ b/requestor/yagna_erigon_manager.py
@@ -97,7 +97,8 @@ class YagnaErigonManager():
 
         #   Stop all Erigons & wait for the Executor to finish
         tasks = [erigon.stop() for erigon in self.erigons]
-        tasks.append(self.executor_task)
+        if self.executor_task is not None:
+            tasks.append(self.executor_task)
 
         await asyncio.gather(*tasks)
 


### PR DESCRIPTION
1. Failed deployment should initialize new deployment attempt on another provider
2. Failed command stops Erigon, task result is still accepted
3. Removed unnecessary `Erigon.start()` together with ugly `start_fut`.

Run: `PYTHONPATH=~/yapapi:$PYTHONPATH python3 requestor_agent_stub.py`
`yapapi` branch: `az/process-batches-error-handling`

General note: there is a mess related to "erigon status" concept. There is `Erigon.started`/`Erigon.stopped` but also `Erigon.runtime_state`. I think this should be addressed somehow - preferably by a clean chart of status flow.

I would prefer to do this in other PR.