### PR TITLE
Fix for event emitter and `delay_for` workaround

### DIFF
--- a/ya-erigon-runtime/Cargo.lock
+++ b/ya-erigon-runtime/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=880efaf19111e71647dea23fd997ebf6edc6e3d7#880efaf19111e71647dea23fd997ebf6edc6e3d7"
+source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=8b9ba5a7a71d919395e6fe54f9012bf6220728c8#8b9ba5a7a71d919395e6fe54f9012bf6220728c8"
 dependencies = [
  "anyhow",
  "directories",
@@ -964,7 +964,7 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk-derive"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=880efaf19111e71647dea23fd997ebf6edc6e3d7#880efaf19111e71647dea23fd997ebf6edc6e3d7"
+source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=8b9ba5a7a71d919395e6fe54f9012bf6220728c8#8b9ba5a7a71d919395e6fe54f9012bf6220728c8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ya-erigon-runtime/Cargo.toml
+++ b/ya-erigon-runtime/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3"
 local_ipaddress = "0.1.3"
 serde = { version = "^1.0", features = ["derive"] }
 structopt = "0.3"
-tokio = { version = "0.2", features = ["io-std", "io-util", "rt-core", "rt-threaded", "macros", "process", "time"] }
+tokio = { version = "0.2", features = ["macros", "process"] }
 
 [patch.crates-io]
-ya-runtime-sdk = { git = "https://github.com/golemfactory/ya-runtime-sdk.git", rev = "880efaf19111e71647dea23fd997ebf6edc6e3d7" }
+ya-runtime-sdk = { git = "https://github.com/golemfactory/ya-runtime-sdk.git", rev = "8b9ba5a7a71d919395e6fe54f9012bf6220728c8" }

--- a/ya-erigon-runtime/src/main.rs
+++ b/ya-erigon-runtime/src/main.rs
@@ -137,7 +137,7 @@ impl Runtime for ErigonRuntime {
         ctx: &mut Context<Self>,
     ) -> ProcessIdResponse<'a> {
         let seq = self.seq.fetch_add(1, Relaxed);
-        let emitter = ctx.emitter.clone().unwrap();
+        let mut emitter = ctx.emitter.clone().unwrap();
 
         let (tx, rx) = oneshot::channel();
         let public_addr = ctx
@@ -169,7 +169,6 @@ impl Runtime for ErigonRuntime {
             .as_bytes()
             .to_vec();
 
-            tokio::time::delay_for(std::time::Duration::from_millis(1)).await;
             emitter.command_stdout(seq, stdout).await;
             emitter.command_stopped(seq, 0).await;
         });


### PR DESCRIPTION
`tokio::time::delay_for` workaround is no longer required due to the fix introduced in https://github.com/golemfactory/ya-runtime-sdk/pull/11

Additionally, unused tokio features have been removed from Cargo.toml.