### PR TITLE
Update Erigon runtime to new runtime API and Erigon

### DIFF
--- a/ya-runtime-erigon/Cargo.lock
+++ b/ya-runtime-erigon/Cargo.lock
@@ -999,7 +999,7 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=880efaf19111e71647dea23fd997ebf6edc6e3d7#880efaf19111e71647dea23fd997ebf6edc6e3d7"
+source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f#5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f"
 dependencies = [
  "anyhow",
  "directories",
@@ -1017,7 +1017,7 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk-derive"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=880efaf19111e71647dea23fd997ebf6edc6e3d7#880efaf19111e71647dea23fd997ebf6edc6e3d7"
+source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f#5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ya-runtime-erigon/Cargo.lock
+++ b/ya-runtime-erigon/Cargo.lock
@@ -824,6 +824,7 @@ checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
  "bytes",
  "fnv",
+ "futures-core",
  "lazy_static",
  "libc",
  "memchr",
@@ -851,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
  "bytes",
  "futures-core",
@@ -963,8 +964,9 @@ dependencies = [
 
 [[package]]
 name = "ya-runtime-api"
-version = "0.2.1"
-source = "git+https://github.com/golemfactory/yagna.git?rev=3d0bee5c12ce64bdb68f11c765f77eab762984ab#3d0bee5c12ce64bdb68f11c765f77eab762984ab"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828c0b288dbda53f1f98dfa3534b5cecca82fce98885cf526fa120513c92cbc"
 dependencies = [
  "anyhow",
  "bytes",
@@ -999,7 +1001,8 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f#5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf574bf441919df5ed91f25d17a55fd0bd55bde489421999e73ba917abe3949"
 dependencies = [
  "anyhow",
  "directories",
@@ -1017,7 +1020,8 @@ dependencies = [
 [[package]]
 name = "ya-runtime-sdk-derive"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-runtime-sdk.git?rev=5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f#5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a82cec28daa7106e038e71119a36da3e182b9f5fa13ab61ebd392cfb3b23620"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ya-runtime-erigon/Cargo.toml
+++ b/ya-runtime-erigon/Cargo.toml
@@ -24,4 +24,4 @@ titlecase = "1.1.0"
 tokio = { version = "0.2", features = ["io-std", "io-util", "rt-core", "rt-threaded", "macros", "process", "time"] }
 
 [patch.crates-io]
-ya-runtime-sdk = { git = "https://github.com/golemfactory/ya-runtime-sdk.git", rev = "880efaf19111e71647dea23fd997ebf6edc6e3d7" }
+ya-runtime-sdk = { git = "https://github.com/golemfactory/ya-runtime-sdk.git", rev = "5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f" }

--- a/ya-runtime-erigon/Cargo.toml
+++ b/ya-runtime-erigon/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-3.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ya-runtime-sdk = { version = "0.1", features = ["macros"] }
+ya-runtime-sdk = { version = "0.1.0", features = ["macros"] }
 
 anyhow = "1.0"
 custom_derive = "0.1.7"
@@ -22,6 +22,3 @@ serde_json = "1.0"
 structopt = "0.3"
 titlecase = "1.1.0"
 tokio = { version = "0.2", features = ["io-std", "io-util", "rt-core", "rt-threaded", "macros", "process", "time"] }
-
-[patch.crates-io]
-ya-runtime-sdk = { git = "https://github.com/golemfactory/ya-runtime-sdk.git", rev = "5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f" }

--- a/ya-runtime-erigon/src/main.rs
+++ b/ya-runtime-erigon/src/main.rs
@@ -11,7 +11,7 @@ use tokio::process::{Child, Command};
 use ya_runtime_sdk::*;
 
 const AUTH_ERIGON_USER: &str = "erigolem";
-const ERIGON_BIN: &str = "tg";
+const ERIGON_BIN: &str = "erigon";
 const RPCDAEMON_BIN: &str = "rpcdaemon";
 const DEFAULT_CHAIN: Network = Network::Goerli;
 


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-152](https://golemproject.atlassian.net/browse/APPS-152)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

<!-- 
DON'T JUST COPY following WHY & WHAT out of JIRA ticket!
Check first if it relates to what this PR delivers
-->

### Why
- We want to avoid problems with updating existing deployments in the future.
- We want nicer tutorial/example on how to implement runtimes.

### What
Update ya-runtime-erigon to use:
- Newest Erigon release (v2021.05.04-alpha)
- Latest yagna runtime SDK ([master-5d857c5, 2021-06-09](https://github.com/golemfactory/ya-runtime-sdk/commit/5d857c5e2fccb5b28a89b5b6fcf78d4c34649c5f))
- Reduce clutter from function responses

## Testing instructions

Try it in the debugger with supported [network values](https://github.com/golemfactory/yagna-service-erigon/blob/3957a286b7992cc6f181c7bacee94ed3b899c0a0/ya-runtime-erigon/src/main.rs#L35-L38)
```bash
ya-runtime-dbg \
  --runtime ./target/debug/ya-runtime-erigon \
  --workdir ./target/debug \
  --start-arg '{"network": "rinkeby"}'
```
![image](https://user-images.githubusercontent.com/1813036/122222882-faabdd80-ceb2-11eb-864f-ea03da4e65e4.png)

### Assumptions 

- Erigon binaries placed in the same directory where the `ya-runtime-erigon` is located

### Response structure returned from `run_command`
Returned response json was cleaned from junk/example text.

```json
{
    "auth": {
        "password": "3gWsNVW1UT7Rvlj",
        "user": "erigolem"
    },
    "network": "rinkeby",
    "url": "http://erigon.localhost:8545"
}
```

<!-- FILL FREE TO ADD OTHER SECTIONS IF NEEDED -->
