### PR TITLE
Serve Erigon frontend on nginx

### DIFF
--- a/requestor/client/src/utils/httpRequest/httpRequest.ts
+++ b/requestor/client/src/utils/httpRequest/httpRequest.ts
@@ -1,7 +1,7 @@
 import request from 'superagent';
 import { HttpRequest, Url } from './types';
 
-const url = ({ path, id }: Url) => `https://erigon.golem.network/${path}${id ? `/${id}` : ''}`;
+const url = ({ path, id }: Url) => `/${path}${id ? `/${id}` : ''}`;
 
 const httpRequest = ({ method = 'post', path, id = '', account, data }: HttpRequest) =>
   request(method.toUpperCase(), url({ path, id }))


### PR DESCRIPTION
This PR resolves following JIRA ticket

- [APPS-169](https://golemproject.atlassian.net/browse/APPS-169)

## Description
### Why
Production frontend should be served from the suitable server

### What
- Hardcoded api url removed
- Build folder shared or fresh build can be done by `yarn build` in `requestor/client` dir

