### PR TITLE
Setup ya-runtime-erigon compilation for ARM64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,12 @@ __pycache__
 *.log
 
 # requestor client dependencies
-requestor/client/node_modules
-requestor/client/.pnp
+client/node_modules
+client/.pnp
 .pnp.js
 
 # requestor client production build
-requestor/client/build
+client/build
 
 # misc
 .DS_Store
@@ -23,3 +23,5 @@ requestor/client/build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+ya-runtime-erigon/*.tar.gz

--- a/ya-runtime-erigon/Makefile
+++ b/ya-runtime-erigon/Makefile
@@ -1,6 +1,8 @@
 .PHONY: clean arm64
+VERSION := $(shell grep -m 1 "version" Cargo.toml | sed -e "s/version = //" | tr -d '"')
+PKG_NAME := "ya-runtime-erigon-arm64-v$(VERSION)"
 
-arm64:
+target/aarch64-unknown-linux-musl/release/ya-runtime-erigon:
 	docker run -it --rm \
 		--workdir /git-repo \
 		--volume $(shell pwd):/git-repo \
@@ -9,5 +11,14 @@ arm64:
 		golemfactory/build-aarch64:0.1.1 \
 		bash -c 'cargo build --release && chown -R $$HOST_USER ./target'
 
+arm64: target/aarch64-unknown-linux-musl/release/ya-runtime-erigon
+	mkdir -p "$(PKG_NAME)/ya-runtime-erigon"
+	cp target/aarch64-unknown-linux-musl/release/ya-runtime-erigon "$(PKG_NAME)/ya-runtime-erigon"
+	sed -e 's/<VERSION>/$(VERSION)/' runtime-descriptor-template.json > "$(PKG_NAME)/ya-runtime-erigon.json"
+	tar -cvzf "$(PKG_NAME).tar.gz" $(PKG_NAME)
+	rm -rf $(PKG_NAME)
+
 clean:
 	rm -rf target
+	rm -rf $(PKG_NAME)
+	rm -f "$(PKG_NAME).tar.gz"

--- a/ya-runtime-erigon/Makefile
+++ b/ya-runtime-erigon/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean arm64
+
+arm64:
+	docker run -it --rm \
+		--workdir /git-repo \
+		--volume $(shell pwd):/git-repo \
+		--volume /etc/passwd:/etc/passwd \
+		--env HOST_USER=`id -u`:`id -g` \
+		golemfactory/build-aarch64:0.1.1 \
+		bash -c 'cargo build --release && chown -R $$HOST_USER ./target'
+
+clean:
+	rm -rf target

--- a/ya-runtime-erigon/runtime-descriptor-template.json
+++ b/ya-runtime-erigon/runtime-descriptor-template.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "erigon",
+    "version": "<VERSION>",
+    "supervisor-path": "exe-unit",
+    "runtime-path": "ya-runtime-erigon/ya-runtime-erigon",
+    "description": "Service wrapper for Erigon",
+    "extra-args": ["--runtime-managed-image"]
+  }
+]


### PR DESCRIPTION
This PR resolves following JIRA ticket

- [APPS-242](https://golemproject.atlassian.net/browse/APPS-242)

## Description

### Why
* We need ARM64 builds to run the runtime on RPi.
* We want to avoid doing this manually on RPi.

### What
Makefile that:
* Builds ARM64 binary of `ya-runtime-erigon` inside a Docker container,
* Creates an tarball with the binary and runtime descriptor.

## Testing instructions

### Assumptions 

[-] Docker required

### How to test

```shell
$ cd ya-runtime-erigon
$ make arm64
...
$ tar -tzf ya-runtime-erigon-arm64-v0.1.0.tar.gz
ya-runtime-erigon-arm64-v0.1.0/
ya-runtime-erigon-arm64-v0.1.0/ya-runtime-erigon/
ya-runtime-erigon-arm64-v0.1.0/ya-runtime-erigon/ya-runtime-erigon
ya-runtime-erigon-arm64-v0.1.0/ya-runtime-erigon.json
```
