### PR TITLE
server runs on gunicorn, graceful shutdown works

### DIFF
--- a/requestor/README.md
+++ b/requestor/README.md
@@ -34,7 +34,7 @@ Default name of this subnet is `erigon`.
 
 ## Stop requestor server gracefully
 
-    docker exec <SERVER-CONTAINER-NAME> bash stop.sh
+    docker stop <SERVER-CONTAINER-NAME>
 
 ## Test requestor server
 

--- a/requestor/README.md
+++ b/requestor/README.md
@@ -16,7 +16,7 @@ Default name of this subnet is `erigon`.
 
 * `run_erigon_service.py` - simple dev script that starts an erigon service and keeps it running until stopped
 * `server` - http server + requestor code ([Quart](https://pgjones.gitlab.io/quart/) + [yapapi-service-manager](https://github.com/golemfactory/yapapi-service-manager))
-* `server.Dockerfile`, `yagna_and_server_init.sh` - `server` running on [docker](https://docs.docker.com/)
+* `server.Dockerfile`, `yagna_and_server_init.sh`, `stop.sh` - `server` running on [docker](https://docs.docker.com/)
 * `client` - frontend code
 * `tests`, `tests.Dockerfile` - test if the server works properly
 
@@ -34,7 +34,7 @@ Default name of this subnet is `erigon`.
 
 ## Stop requestor server gracefully
 
-    docker exec -it <SERVER-CONTAINER-NAME> pkill python
+    docker exec <SERVER-CONTAINER-NAME> bash stop.sh
 
 ## Test requestor server
 

--- a/requestor/README.md
+++ b/requestor/README.md
@@ -16,7 +16,7 @@ Default name of this subnet is `erigon`.
 
 * `run_erigon_service.py` - simple dev script that starts an erigon service and keeps it running until stopped
 * `server` - http server + requestor code ([Quart](https://pgjones.gitlab.io/quart/) + [yapapi-service-manager](https://github.com/golemfactory/yapapi-service-manager))
-* `server.Dockerfile`, `yagna_and_server_init.sh`, `stop.sh` - `server` running on [docker](https://docs.docker.com/)
+* `server.Dockerfile`, `yagna_and_server_init.sh` - `server` running on [docker](https://docs.docker.com/)
 * `client` - frontend code
 * `tests`, `tests.Dockerfile` - test if the server works properly
 

--- a/requestor/requirements.txt
+++ b/requestor/requirements.txt
@@ -2,4 +2,7 @@ Quart==0.15.1
 quart-cors==0.5.0
 web3==5.20.0
 
+gunicorn==20.1.0
+uvicorn==0.15.0
+
 git+https://github.com/golemfactory/yapapi-service-manager.git

--- a/requestor/server.Dockerfile
+++ b/requestor/server.Dockerfile
@@ -22,12 +22,11 @@ RUN python3 -m pip install -r requirements.txt
 RUN rm yagna.deb requirements.txt
 
 COPY yagna_and_server_init.sh .
-COPY stop.sh                  .
-RUN chmod +x yagna_and_server_init.sh stop.sh
+RUN chmod +x yagna_and_server_init.sh
 
 COPY server        server
 COPY run_server.py run_server.py
 
 ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT ./yagna_and_server_init.sh
+ENTRYPOINT ["./yagna_and_server_init.sh"]

--- a/requestor/server.Dockerfile
+++ b/requestor/server.Dockerfile
@@ -22,7 +22,8 @@ RUN python3 -m pip install -r requirements.txt
 RUN rm yagna.deb requirements.txt
 
 COPY yagna_and_server_init.sh .
-RUN chmod +x yagna_and_server_init.sh
+COPY stop.sh                  .
+RUN chmod +x yagna_and_server_init.sh stop.sh
 
 COPY server        server
 COPY run_server.py run_server.py

--- a/requestor/stop.sh
+++ b/requestor/stop.sh
@@ -1,9 +1,0 @@
-#   Stop the server gracefully.
-#   The best way to ensure graceful yapapi shutdown is to send SIGTERM (15) 
-#   to the main gunicorn process and this is not obvious at all, thus this script.
-#   (check e.g. https://github.com/benoitc/gunicorn/issues/2604)
-
-#   NOTE: we can't use the standard `docker stop ...` because gunicorn is not the
-#   "main" container process - the main process is yagna_and_server_init.sh.
-GUNICORN_MASTER_PID=$(ps -aux | grep gunicorn | tr -s ' ' | cut -d ' ' -f2 | sort -n | head -1)
-kill -15 $GUNICORN_MASTER_PID

--- a/requestor/stop.sh
+++ b/requestor/stop.sh
@@ -1,0 +1,9 @@
+#   Stop the server gracefully.
+#   The best way to ensure graceful yapapi shutdown is to send SIGTERM (15) 
+#   to the main gunicorn process and this is not obvious at all, thus this script.
+#   (check e.g. https://github.com/benoitc/gunicorn/issues/2604)
+
+#   NOTE: we can't use the standard `docker stop ...` because gunicorn is not the
+#   "main" container process - the main process is yagna_and_server_init.sh.
+GUNICORN_MASTER_PID=$(ps -aux | grep gunicorn | tr -s ' ' | cut -d ' ' -f2 | sort -n | head -1)
+kill -15 $GUNICORN_MASTER_PID

--- a/requestor/yagna_and_server_init.sh
+++ b/requestor/yagna_and_server_init.sh
@@ -21,5 +21,6 @@ sleep 5
 #   3.  Set the environment for the server app
 export YAGNA_APPKEY=$(yagna app-key list | tail -2 | head -1 | head -c53 | tail -c32)
 
-#   4.  Start server (TODO: gunicorn run)
-python3 run_server.py
+#   4.  Start the server
+#       NOTE: this will not work with more than one worker, don't try that
+gunicorn -b 0.0.0.0:5000 -k uvicorn.workers.UvicornWorker run_server:app

--- a/requestor/yagna_and_server_init.sh
+++ b/requestor/yagna_and_server_init.sh
@@ -22,5 +22,7 @@ sleep 5
 export YAGNA_APPKEY=$(yagna app-key list | tail -2 | head -1 | head -c53 | tail -c32)
 
 #   4.  Start the server
-#       NOTE: this will not work with more than one worker, don't try that
-gunicorn -b 0.0.0.0:5000 -k uvicorn.workers.UvicornWorker run_server:app
+#       NOTE:  this will not work with more than one worker, don't try that
+#       NOTE2: `exec` because we want gunicorn to become the main process 
+#              (and thus the target of SIGTERM sent by `docker stop`)
+exec gunicorn -b 0.0.0.0:5000 -k uvicorn.workers.UvicornWorker run_server:app


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-179](https://golemproject.atlassian.net/browse/APPS-179)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

### Why

We want to:
* run the http server the way it should be run (i.e. using `gunicorn` or some other server)
* make sure yapapi shuts down gracefully

### What

The only thing missing was the fact that we have to pass SIGTERM to the main `gunicorn` process to ensure SIGINT (and thus graceful shutdown) in workers. So in this PR server is started with `gunicorn` and there is an additional `stop.sh` two-line script.


## Testing instructions

Start the server. Run some tests. Stop the server. Check if yapapi logs look the way they should look.
Details in the README.
