### PR TITLE
Changes to stabilize erigolem backend on new runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The application consist of three major components:
 
 ---
 
-To use the application locally, run `docker-compose up` and open [http://localhost:8000]()
+To use the application locally, run `docker-compose up` and open [http://localhost:8000](). You can provide your own subnet by setting up the `SUBNET_TAG` environment variable.
 
 Instructions how to run and test the requestor server are [here](https://github.com/golemfactory/yagna-service-erigon/blob/master/requestor/README.md).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
             dockerfile: server.Dockerfile
             context: ./requestor
         image: erigon-server
+        environment:
+            - SUBNET_TAG=${SUBNET_TAG:-erigon}
         ports:
             - 5000:5000
 

--- a/requestor/server/erigon_service.py
+++ b/requestor/server/erigon_service.py
@@ -40,7 +40,7 @@ class Erigon(Service):
         self._ctx.run('STATUS')
         processing_future = yield self._ctx.commit()
         result = self._parse_status_result(processing_future.result())
-        self.url, self.auth, self.network = result['url'], result['auth'], result['network']
+        self.url, self.auth, self.network = result['url'], result['auth'], result.get('network', 'mainnet')
 
     @staticmethod
     def _parse_status_result(raw_data: 'List[CommandExecuted]'):


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-275](https://golemproject.atlassian.net/browse/APPS-275)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

<!-- 
DON'T JUST COPY following WHY & WHAT out of JIRA ticket!
Check first if it relates to what this PR delivers
-->

### Why
- We want to make sure everything works end-to-end in the ‘rent a node’ scenario.

### What
- Check the [Jira ticket](https://golemproject.atlassian.net/browse/APPS-275) for more details


## Testing instructions

Assuming there is running golemsp with the `yagna-service-erigon` runtime under some `subnet` tag.

- Start the erigolem services with `SUBNET_TAG=subnet docker-compose up`
- Navigate your browser to `http://localhost:8000`
- Connect MetaMask 🦊 and start a new node :)



