### PR TITLE
Basic auth runtime configuration example

### DIFF
--- a/ya-runtime-basic-auth/example_config/README.md
+++ b/ya-runtime-basic-auth/example_config/README.md
@@ -1,0 +1,52 @@
+# Example configuration of Basic-Auth runtime
+
+Here we will present example configuration of the Golem provider tool `golemsp`
+that serves 2 authentication runtimes for `erigon` and `lighthouse` clients.
+
+## Directory structure
+
+You can find following files in this directory. Bellow we explain them in more details
+
+```bash
+├── plugins
+│  ├── ya-runtime-erigon.json
+│  └── ya-runtime-lhouse.json
+├── ya-provider
+│  └── presets.json
+├── ya-runtime-erigon
+│  └── ya-runtime-erigon.json
+└── ya-runtime-lhouse
+   └── ya-runtime-lhouse.json
+```
+
+### 1. Yagna plugins
+
+In this directory plugin's bianries and descriptors are placed.
+
+Directory tree may looks like bellow:
+```bash
+~/.local/lib/yagna/plugins
+├── exe-unit
+├── ya-runtime-basic-auth
+│  └── ya-runtime-basic-auth
+├── ya-runtime-erigon.json
+├── ya-runtime-lhouse.json
+├── ya-runtime-vm
+│  ├── runtime
+│  │  ├── ...
+│  └── ya-runtime-vm
+├── ya-runtime-vm.json
+├── ya-runtime-wasi
+└── ya-runtime-wasi.json
+```
+
+### 2. Provider's preset.json file
+
+The `preset.json` file is located in `~/.local/share/ya-provider/` directory.
+It's overwritten by `golemsp` (TODO: more info needed)
+
+### 3. Runtime configuration files
+
+The `golemsp` tool loads plugins and search for the configuration files in `~/.local/share/<runtime-name>/<runtime-name>.json` 
+In this directory we present sample configuration of `ya-runtime-erigon` and `ya-runtime-lhouse` runtimes.
+

--- a/ya-runtime-basic-auth/example_config/plugins/ya-runtime-erigon.json
+++ b/ya-runtime-basic-auth/example_config/plugins/ya-runtime-erigon.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "erigon",
+    "version": "0.1.0",
+    "supervisor-path": "exe-unit",
+    "runtime-path": "ya-runtime-basic-auth/ya-runtime-basic-auth",
+    "description": "authentication runtime for erigon",
+    "extra-args": ["--runtime-managed-image"]
+  }
+]
+

--- a/ya-runtime-basic-auth/example_config/plugins/ya-runtime-lhouse.json
+++ b/ya-runtime-basic-auth/example_config/plugins/ya-runtime-lhouse.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "lhouse",
+    "version": "0.1.0",
+    "supervisor-path": "exe-unit",
+    "runtime-path": "ya-runtime-basic-auth/ya-runtime-basic-auth",
+    "description": "authentication runtime for LightHouse",
+    "extra-args": ["--runtime-managed-image"]
+  }
+]
+

--- a/ya-runtime-basic-auth/example_config/ya-provider/presets.json
+++ b/ya-runtime-basic-auth/example_config/ya-provider/presets.json
@@ -1,0 +1,69 @@
+{
+  "ver": "V1",
+  "active": [
+    "erigon",
+    "lhouse",
+    "wasmtime",
+    "vm",
+    "ya-runtime-erigon"
+  ],
+  "presets": [
+    {
+      "name": "default",
+      "exeunit-name": "wasmtime",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {}
+    },
+    {
+      "name": "vm",
+      "exeunit-name": "vm",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {
+        "golem.usage.cpu_sec": 0.00002777777777777778,
+        "golem.usage.duration_sec": 5.555555555555556e-6
+      }
+    },
+    {
+      "name": "ya-runtime-erigon",
+      "exeunit-name": "ya-runtime-erigon",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {
+        "golem.usage.cpu_sec": 0.00002777777777777778,
+        "golem.usage.duration_sec": 5.555555555555556e-6
+      }
+    },
+    {
+      "name": "wasmtime",
+      "exeunit-name": "wasmtime",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {
+        "golem.usage.duration_sec": 5.555555555555556e-6,
+        "golem.usage.cpu_sec": 0.00002777777777777778
+      }
+    },
+    {
+      "name": "lhouse",
+      "exeunit-name": "lhouse",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {
+        "golem.usage.cpu_sec": 0.00002777777777777778,
+        "golem.usage.duration_sec": 5.555555555555556e-6
+      }
+    },
+    {
+      "name": "erigon",
+      "exeunit-name": "ya-runtime-erigon",
+      "pricing-model": "linear",
+      "initial-price": 0.0,
+      "usage-coeffs": {
+        "golem.usage.cpu_sec": 0.00002777777777777778,
+        "golem.usage.duration_sec": 5.555555555555556e-6
+      }
+    }
+  ]
+}

--- a/ya-runtime-basic-auth/example_config/ya-runtime-erigon/ya-runtime-erigon.json
+++ b/ya-runtime-basic-auth/example_config/ya-runtime-erigon/ya-runtime-erigon.json
@@ -1,0 +1,7 @@
+{
+  "service_prefix": "erigon",
+  "public_addr": "http://erigon.service:8080",
+  "passwd_tool_path": "htpasswd",
+  "passwd_file_path": "/home/pnowosie/.local/share/ya-runtime-erigon/htpasswd",
+  "password_default_length": 15
+}

--- a/ya-runtime-basic-auth/example_config/ya-runtime-lhouse/ya-runtime-lhouse.json
+++ b/ya-runtime-basic-auth/example_config/ya-runtime-lhouse/ya-runtime-lhouse.json
@@ -1,0 +1,7 @@
+{
+  "service_prefix": "lighthouse",
+  "public_addr": "http://lhouse.service:8080",
+  "passwd_tool_path": "htpasswd",
+  "passwd_file_path": "/home/pnowosie/.local/share/ya-runtime-lhouse/htpasswd",
+  "password_default_length": 15
+}


### PR DESCRIPTION
This PR follows up to PR #46 and provides configuration & test instructions.


<!-- Link you JIRA ticket below--> 
- [APPS-345](https://golemproject.atlassian.net/browse/APPS-345)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

<!-- 
DON'T JUST COPY following WHY & WHAT out of JIRA ticket!
Check first if it relates to what this PR delivers
-->

### Why

- having generic auth service I'd like to configure multiple endopoint authenticated with it.

### What

- this will not work until golemfactory/yagna#1702 is implemented, for now runtime's cargo project name is used to resolve path to the configuration file. 


## Testing instructions

### Start provider daemon
In the new terminal window execute command:
- `golemsp run --payment-network rinkeby --subnet subnet`


### Start requestor daemon
In the new terminal window, 
- navigate to yagna-service-erigon root directory
- execute `SUBNET_TAG=subnet docker-compose up requestor`

### Start tests
In the new terminal window, 
- navigate to `requestor` directory
- execute `docker run --network=host -e BASE_URL=localhost:5000 erigon-server-test`


### Assumptions 

- Services (e.g. erigon, lighthouse...) run independently from golem deamon.
- nginx is configured as proxy to these ☝️ services with authentication layer on top
- Basic-Auth runtime instances just add/remove users in the appropriate `htpasswd` files

<!-- FILL FREE TO ADD OTHER SECTIONS IF NEEDED -->
