### PR TITLE
Erigolem CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,19 @@ Instructions how to run client and e2e tests are [here](https://github.com/golem
 Instructions how to run and test the requestor server are [here](https://github.com/golemfactory/yagna-service-erigon/blob/master/requestor/README.md).
 
 Full project documentation can be found in the [Golem handbook](https://handbook.golem.network/requestor-tutorials/service-development/service-example-2-managed-erigon).
+
+---
+ 
+You can use CLI to interact with the requestor server. First, generate a `keystore.json` file. You can export from yagna or use [vanity-eth](https://vanity-eth.tk/). Then you can list, create and stop erigon instances:
+```shell
+$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list 
+[]
+$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD>  create '{"name": "My Node", "params": {"network": "goerli"}}'
+{'created_at': '2022-03-07T15:35:59.355692', 'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'init_params': {'network': 'goerli'}, 'name': 'My Node', 'status': 'pending'}
+$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list
+[{'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'status': 'running', 'name': 'My Node', 'init_params': {'network': 'goerli'}, 'created_at': '2022-03-07T15:35:59.355692', 'url': 'https://0.erigon.golem.network:8545', 'auth': {'password': '4P0o087q43FlmoP', 'user': 'erigolem'}, 'network': 'goerli'}]
+$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> stop a2303ae2c2de4a83a86a8fa69cb9b303
+{'auth': {'password': '4P0o087q43FlmoP', 'user': 'erigolem'}, 'created_at': '2022-03-07T15:35:59.355692', 'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'init_params': {'network': 'goerli'}, 'name': 'My Node', 'network': 'goerli', 'status': 'running', 'url': 'https://0.erigon.golem.network:8545'}
+$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list 
+[{'id': 'ce139636bb794d2990261aff71651416', 'status': 'failed', 'name': 'erigon_ce139636bb794d2990261aff71651416', 'init_params': {'name': 'My Node', 'params': {'network': 'goerli'}}, 'created_at': '2022-03-07T15:34:51.311091'}, {'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'status': 'stopped', 'name': 'My Node', 'init_params': {'network': 'goerli'}, 'created_at': '2022-03-07T15:35:59.355692', 'stopped_at': '2022-03-07T15:36:31.939827'}]
+```

--- a/requestor/erigolem_cli.py
+++ b/requestor/erigolem_cli.py
@@ -1,0 +1,79 @@
+import json
+import typing
+import urllib.parse as urlparse
+
+import click
+import requests
+from web3.auto import w3
+
+if typing.TYPE_CHECKING:
+    from typing import TextIO, Optional, Any
+
+
+class ErigolemClient:
+    def __init__(self, erigolem_url: str, keystore: 'TextIO', password: str):
+        if not erigolem_url.endswith('/'):
+            erigolem_url += '/'
+        self._erigolem_url = erigolem_url
+        private_key = w3.eth.account.decrypt(keystore.read(), password)
+        self._account = w3.eth.account.from_key(private_key)
+        self._session = requests.Session()
+        self._session.headers.update({'Authorization': f'Bearer {self._account.address}'})
+
+    def _get(self, url: str) -> dict:
+        url = urlparse.urljoin(self._erigolem_url, url)
+        response = self._session.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    def _post(self, url: str, data: 'Optional[Any]' = None) -> dict:
+        url = urlparse.urljoin(self._erigolem_url, url)
+        response = self._session.post(url, json=data)
+        response.raise_for_status()
+        return response.json()
+
+    def get_instances(self) -> 'dict[str, dict]':
+        return self._get('getInstances')
+
+    def create_instance(self, params: dict) -> dict:
+        return self._post('createInstance', data=params)
+
+    def stop_instance(self, instance_id: str) -> dict:
+        return self._post(f'stopInstance/{instance_id}')
+
+
+@click.group()
+@click.option('--erigolem-url', default='http://localhost:5000/', envvar='ERIGOLEM_URL')
+@click.option('--keystore', type=click.File(), envvar='KEYSTORE')
+@click.option('--password', envvar='PASSWORD')
+@click.pass_context
+def cli(ctx, erigolem_url, keystore, password):
+    ctx.obj = ErigolemClient(erigolem_url, keystore, password)
+
+
+@cli.command(name='list')
+@click.pass_obj
+def get_instances(client: ErigolemClient):
+    instances = client.get_instances()
+    click.echo(instances)
+
+
+@cli.command(name='create')
+@click.argument('params')
+@click.pass_obj
+def create_instance(client: ErigolemClient, params: str):
+    params_dict = json.loads(params)
+    instance = client.create_instance(params_dict)
+    click.echo(instance)
+
+
+@cli.command(name='stop')
+@click.argument('instance_id')
+@click.pass_obj
+def stop_instance(client: ErigolemClient, instance_id: str):
+    instance = client.stop_instance(instance_id)
+    click.echo(instance)
+
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-524](https://golemproject.atlassian.net/browse/APPS-524)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

<!-- 
DON'T JUST COPY following WHY & WHAT out of JIRA ticket!
Check first if it relates to what this PR delivers
-->

### Why

* Allows easier manual testing/debugging of Erigolem.
* Will be used for network checker in the future.

### What

* A simple Python CLI for Erigolem.

## Testing instructions

### Assumptions 

* Python
* Docker
* Docker-compose

### How to test

1. Start your local Erigolem server and wait for application startup.
```shell
$ docker-compose up
...
requestor_1  | [2022-03-07 15:02:24 +0000] [76] [INFO] Application startup complete.
```

2. (In another console) Create a virtual env and install dependencies.
```shell
$ python3 -m venv .venv
$ . .venv/bin/activate
$ pip install -r requestor/requirements.txt
```

3. Generate a `keystore.json` file. You can export from yagna or use [vanity-eth](https://vanity-eth.tk/).

4. Run a few commands and check the outputs.
```shell
$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list 
[]
$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD>  create '{"name": "My Node", "params": {"network": "goerli"}}'
{'created_at': '2022-03-07T15:35:59.355692', 'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'init_params': {'network': 'goerli'}, 'name': 'My Node', 'status': 'pending'}
$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list
[{'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'status': 'running', 'name': 'My Node', 'init_params': {'network': 'goerli'}, 'created_at': '2022-03-07T15:35:59.355692', 'url': 'https://0.erigon.golem.network:8545', 'auth': {'password': '4P0o087q43FlmoP', 'user': 'erigolem'}, 'network': 'goerli'}]
$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> stop a2303ae2c2de4a83a86a8fa69cb9b303
{'auth': {'password': '4P0o087q43FlmoP', 'user': 'erigolem'}, 'created_at': '2022-03-07T15:35:59.355692', 'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'init_params': {'network': 'goerli'}, 'name': 'My Node', 'network': 'goerli', 'status': 'running', 'url': 'https://0.erigon.golem.network:8545'}
$ python requestor/erigolem_cli.py --keystore ./keystore.json --password <PASSWORD> list 
[{'id': 'ce139636bb794d2990261aff71651416', 'status': 'failed', 'name': 'erigon_ce139636bb794d2990261aff71651416', 'init_params': {'name': 'My Node', 'params': {'network': 'goerli'}}, 'created_at': '2022-03-07T15:34:51.311091'}, {'id': 'a2303ae2c2de4a83a86a8fa69cb9b303', 'status': 'stopped', 'name': 'My Node', 'init_params': {'network': 'goerli'}, 'created_at': '2022-03-07T15:35:59.355692', 'stopped_at': '2022-03-07T15:36:31.939827'}]
```