### PR TITLE
Network checker dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The application consist of three major components:
 
 ---
 
-To use the application locally, run `docker-compose up` and open [http://localhost:8000](). You can provide your own subnet by setting up the `SUBNET_TAG` environment variable.
+To use the application locally, run `docker-compose up` and open [http://localhost:8000](). You can provide your own subnet by setting up the `SUBNET_TAG` environment variable. The default `docker-compose.yml` config starts the requestor server and frontend. To start the network checker as well, include `-f network-checker.yml`.
 
 Instructions how to run client and e2e tests are [here](https://github.com/golemfactory/yagna-service-erigon/blob/master/client/README.md).
 Instructions how to run and test the requestor server are [here](https://github.com/golemfactory/yagna-service-erigon/blob/master/requestor/README.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
             - SUBNET_TAG=${SUBNET_TAG:-erigon}
         ports:
             - 5000:5000
+        healthcheck:
+            test: ["CMD", "curl", "http://localhost:5000"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
 
     client:
         build:
@@ -21,3 +26,5 @@ services:
             - API_URL=http://requestor:5000
         ports:
             - 8000:80
+        depends_on:
+            - requestor

--- a/network-checker.yml
+++ b/network-checker.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+
+    network_checker:
+        build:
+            dockerfile: network_checker.Dockerfile
+            context: ./requestor
+        image: network-checker
+        environment:
+            - ERIGOLEM_URL=http://requestor:5000
+            - NUM_INSTANCES=2
+        depends_on:
+            - requestor

--- a/requestor/erigolem_cli.py
+++ b/requestor/erigolem_cli.py
@@ -217,7 +217,7 @@ class NetworkChecker:
 @click_logging.simple_verbosity_option(logger, '-l', '--log-level')
 @click.option('--erigolem-url', default='http://localhost:5000/', envvar='ERIGOLEM_URL')
 @click.option('--keystore', type=click.File(), default='keystore.json', envvar='KEYSTORE')
-@click.option('--password', envvar='PASSWORD')
+@click.option('--password', default='', envvar='PASSWORD')
 @click.pass_context
 def cli(ctx, erigolem_url, keystore, password):
     ctx.obj = ErigolemClient(erigolem_url, keystore, password)

--- a/requestor/gen_keystore.py
+++ b/requestor/gen_keystore.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import json
+
+import click
+from web3.auto import w3
+
+
+@click.command()
+@click.option('--keystore', type=click.File(mode='w'), default='keystore.json', envvar='KEYSTORE')
+@click.option('--password', default='', envvar='PASSWORD')
+def generate_keystore(keystore, password):
+    account = w3.eth.account.create()
+    encrypted = account.encrypt(password=password)
+    json.dump(encrypted, keystore)
+
+
+if __name__ == '__main__':
+    generate_keystore()

--- a/requestor/network_checker.Dockerfile
+++ b/requestor/network_checker.Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim
+WORKDIR /network_checker/
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+COPY erigolem_cli.py .
+COPY gen_keystore.py .
+RUN python3 ./gen_keystore.py
+
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python3", "./erigolem_cli.py", "net-check"]


### PR DESCRIPTION
This PR resolves following JIRA ticket

<!-- Link you JIRA ticket below--> 
- [APPS-526](https://golemproject.atlassian.net/browse/APPS-526)
<!--
IMPORTANT: If the changes resolves only part of the task - explain here which part and point to other related PRs 
-->

## Description

Dockerfile + docker-compose config allowing to run the whole app in one command.


## Testing instructions

Just run `docker-compose -f docker-compose.yml -f network-checker.yml up` from the main directory. It should start the requestor service and network checker.
```shell
$ docker-compose -f docker-compose.yml -f network-checker.yml up
...
requestor_1        | [2022-03-21 21:21:04 +0000] [77] [INFO] Application startup complete.
network_checker_1  | Starting network check...
network_checker_1  | Active instances: 0 / 2
network_checker_1  | Creating 2 new instances...
network_checker_1  | Creating new instance...
network_checker_1  | Instance ea37cbcf9bdd472f8aace06242111b23 created
network_checker_1  | Creating new instance...
network_checker_1  | Instance 196e9d070084402ea9bc78e87a2ff05c created
network_checker_1  | Finished creating new instances
network_checker_1  | Network check done
requestor_1        | Using subnet: erigon  payment driver: zksync  network: rinkeby
requestor_1        | 
requestor_1        | [2022-03-21T21:21:58.643+0000 INFO yapapi.summary] Agreement proposed to provider 'erigon-1'
requestor_1        | [2022-03-21T21:21:58.652+0000 INFO yapapi.summary] Agreement proposed to provider 'erigon-1'
requestor_1        | [2022-03-21T21:21:58.882+0000 INFO yapapi.summary] Agreement confirmed by provider 'erigon-1'
requestor_1        | [2022-03-21T21:21:59.134+0000 INFO yapapi.summary] Received proposals from 1 provider so far
requestor_1        | [2022-03-21T21:21:59.765+0000 INFO yapapi.services] <Erigon: b74c18c7fa2b453e987363f0c350b298> commissioned
requestor_1        | [2022-03-21T21:21:59.770+0000 INFO yapapi.summary] Task started on provider 'erigon-1', task data: Service: Erigon
network_checker_1  | Starting network check...
network_checker_1  | Active instances: 2 / 2
network_checker_1  | Instance 196e9d070084402ea9bc78e87a2ff05c is stale and will be recreated
network_checker_1  | Stopping instance 196e9d070084402ea9bc78e87a2ff05c ...
requestor_1        | STOPPING Erigon[id=196e9d070084402ea9bc78e87a2ff05c]
network_checker_1  | Instance 196e9d070084402ea9bc78e87a2ff05c stopped.
network_checker_1  | Creating new instance...
network_checker_1  | Instance abdd2660290b4cca85004775d19dd0e7 created
network_checker_1  | Network check done
requestor_1        | [2022-03-21T21:22:54.272+0000 INFO yapapi.summary] Agreement proposed to provider 'erigon-0'
requestor_1        | [2022-03-21T21:22:54.651+0000 INFO yapapi.summary] Agreement confirmed by provider 'erigon-0'
requestor_1        | [2022-03-21T21:22:54.972+0000 INFO yapapi.summary] Agreement proposed to provider 'erigon-0'
requestor_1        | [2022-03-21T21:22:56.154+0000 INFO yapapi.summary] Received proposals from 2 providers so far
requestor_1        | [2022-03-21T21:22:56.263+0000 INFO yapapi.services] <Erigon: 6614d259875b453fa2464cb0303d1933> commissioned
requestor_1        | [2022-03-21T21:22:56.263+0000 INFO yapapi.summary] Task started on provider 'erigon-0', task data: Service: Erigon
network_checker_1  | Starting network check...
network_checker_1  | Active instances: 2 / 2
network_checker_1  | Network check done
...
```

